### PR TITLE
Précise le push sur la branche dev-codex

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,9 @@
+# AGENTS
+
+Cette base AGENTS fournit quelques règles simples :
+
+- Toutes les contributions doivent être en français.
+- Exécutez les tests en lançant `pytest` si un dossier de tests existe avant de commiter.
+- Suivez les instructions plus spécifiques dans les fichiers AGENTS.md des sous-dossiers, s'il y en a.
+- L'agent Codex doit pousser automatiquement les commits sur la branche `dev-codex`.
+- Les fichiers de règles doivent s'appeler **AGENTS.md** (en majuscules).


### PR DESCRIPTION
## Notes
- Ajout d'une consigne dans `AGENTS.md` pour pousser automatiquement les commits sur `dev-codex`.
- Indication que le fichier de règles se nomme `AGENTS.md`.
- Aucun test trouvé, `pytest` n'a donc pas pu être exécuté.
